### PR TITLE
Create a subdirectory for the remote repo

### DIFF
--- a/core/src/main/kotlin/com/tinder/gitquery/core/GitQueryCore.kt
+++ b/core/src/main/kotlin/com/tinder/gitquery/core/GitQueryCore.kt
@@ -24,7 +24,10 @@ object GitQueryCore {
         val config = loadConfig(configFile)
         validateConfig(config.remote, config.branch)
 
-        prepareRepo(config.remote, config.branch, repoPath)
+        val actualRepoPath = "$repoPath/" +
+                config.remote.substring(config.remote.lastIndexOf("/")).removeSuffix(".git")
+
+        prepareRepo(config.remote, config.branch, actualRepoPath)
 
         prepareOutputDirectory(outputPath)
 
@@ -33,7 +36,7 @@ object GitQueryCore {
             fileMap = config.files,
             remote = config.remote,
             commits = config.commits,
-            repoPath = repoPath,
+            repoPath = actualRepoPath,
             outputPath = outputPath,
             relativePath = ""
         )
@@ -149,7 +152,7 @@ object GitQueryCore {
      * Check for and create the output folder - relative to projectDir. Throws exceptions if there are issues.
      */
     private fun prepareOutputDirectory(outputPath: String) {
-        println("Creating outputPath: $outputPath")
+        println("GitQuery: creating outputPath: $outputPath")
 
         // Either outputPath exists or we can create it
         check(0 == sh("[ -d $outputPath ] || mkdir -p $outputPath")) {

--- a/gradle-plugin/src/test/kotlin/com/tinder/gitquery/e2e/GitQueryTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/tinder/gitquery/e2e/GitQueryTaskTest.kt
@@ -42,7 +42,7 @@ class GitQueryTaskTest {
             .withPluginClasspath()
             .build()
         assert(result.task(":gitQueryTask")?.outcome == TaskOutcome.SUCCESS)
-        assert(result.output.contains("Creating outputPath"))
+        assert(result.output.contains("GitQuery: creating outputPath"))
         assert(File("${testProjectDir.root}/synced-src/definitions/user.proto").exists())
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 GROUP=com.tinder.gitquery
-VERSION_NAME=1.0.3-SNAPSHOT
+VERSION_NAME=1.1.0-SNAPSHOT
 
 POM_DESCRIPTION=A library for querying and syncing files in a remote git repo.
 POM_URL=https://github.com/Tinder/GitQuery


### PR DESCRIPTION
Create this under the repo_dir. This will avoid accidentally rm-ing the currently folder if the repo_dir param is empty.