### PR TITLE
Fix plugin group

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 }
 
 val VERSION_NAME: String by project
+val GROUP: String by project
 
 gradlePlugin {
     plugins {
@@ -37,7 +38,7 @@ pluginBundle {
         }
     }
     mavenCoordinates {
-        groupId = project.group as String
+        groupId = GROUP
         artifactId = "gitquery-plugin"
         version = VERSION_NAME
     }


### PR DESCRIPTION
Your plugin was flagged for manual review because of the following issue(s):

the plugin group (GitQuery) specified could be misleading. The group should be related to the organization responsible.
the plugin id (com.tinder.gitquery) and your email account do not appear to be related
Please resubmit your plugin once you have corrected these issues to be reconsidered for approval. Your plugin submission has been cancelled, so you may reuse the same version number.